### PR TITLE
Fix invisible font issue

### DIFF
--- a/config
+++ b/config
@@ -5,13 +5,13 @@
 [profiles]
   [[default]]
     # solarized-dark
-    #palette = "#073642:#dc322f:#859900:#b58900:#268bd2:#d33682:#2aa198:#eee8d5:#002b36:#cb4b16:#586e75:#657b83:#839496:#6c71c4:#93a1a1:#fdf6e3"
+    #palette = "#073642:#dc322f:#859900:#b58900:#268bd2:#d33682:#2aa198:#eee8d5:#586e75:#cb4b16:#586e75:#657b83:#839496:#6c71c4:#93a1a1:#fdf6e3"
     #foreground_color = "#eee8d5"
     #background_color = "#002b36"
     #cursor_color = "#eee8d5"
 
   [[solarized-dark]]
-    palette = "#073642:#dc322f:#859900:#b58900:#268bd2:#d33682:#2aa198:#eee8d5:#002b36:#cb4b16:#586e75:#657b83:#839496:#6c71c4:#93a1a1:#fdf6e3"
+    palette = "#073642:#dc322f:#859900:#b58900:#268bd2:#d33682:#2aa198:#eee8d5:#586e75:#cb4b16:#586e75:#657b83:#839496:#6c71c4:#93a1a1:#fdf6e3"
     foreground_color = "#eee8d5"
     background_color = "#002b36"
     cursor_color = "#eee8d5"


### PR DESCRIPTION
umayr created a fork that fixed an invisible font issue when using the dark theme. I'm opening the pull request because the problem was driving me nuts, and the fix seems to be working well in both themes.
